### PR TITLE
Fix nondeterministic test

### DIFF
--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SeedStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SeedStrategy.java
@@ -26,7 +26,7 @@ import org.apache.tinkerpop.gremlin.process.traversal.step.Seedable;
 import org.apache.tinkerpop.gremlin.process.traversal.strategy.AbstractTraversalStrategy;
 import org.apache.tinkerpop.gremlin.process.traversal.util.TraversalHelper;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -75,9 +75,9 @@ public class SeedStrategy extends AbstractTraversalStrategy<TraversalStrategy.De
 
     @Override
     public Configuration getConfiguration() {
-        final Map<String, Object> map = new HashMap<>();
-        map.put(STRATEGY, SeedStrategy.class.getCanonicalName());
+        final Map<String, Object> map = new LinkedHashMap<>();
         map.put(ID_SEED, this.seed);
+        map.put(STRATEGY, SeedStrategy.class.getCanonicalName());
         return new MapConfiguration(map);
     }
 

--- a/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
+++ b/gremlin-core/src/main/java/org/apache/tinkerpop/gremlin/process/traversal/strategy/decoration/SubgraphStrategy.java
@@ -56,7 +56,7 @@ import org.apache.tinkerpop.gremlin.structure.VertexProperty;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -310,14 +310,14 @@ public final class SubgraphStrategy extends AbstractTraversalStrategy<TraversalS
 
     @Override
     public Configuration getConfiguration() {
-        final Map<String, Object> map = new HashMap<>();
-        if (null != this.vertexCriterion)
-            map.put(VERTICES, this.vertexCriterion);
+        final Map<String, Object> map = new LinkedHashMap<>();
+        map.put(CHECK_ADJACENT_VERTICES, this.checkAdjacentVertices);
         if (null != this.edgeCriterion)
             map.put(EDGES, this.edgeCriterion);
         if (null != this.vertexPropertyCriterion)
             map.put(VERTEX_PROPERTIES, this.vertexPropertyCriterion);
-        map.put(CHECK_ADJACENT_VERTICES, this.checkAdjacentVertices);
+        if (null != this.vertexCriterion)
+            map.put(VERTICES, this.vertexCriterion);
         return new MapConfiguration(map);
     }
 


### PR DESCRIPTION
<!--
Thanks for contributing! Reminders:
+ TARGET the earliest branch where you want the change
    3.6-dev -> 3.6.8 (bugs only)
    3.7-dev -> 3.7.3 (non-breaking)
    master  -> 4.0.0
+ Committers will MERGE the PR forward to newer versions
+ ADD entry to the CHANGELOG.asciidoc for the targeted version
    Do not reference a JIRA number there
+ ADD JIRA number to title and link in description
+ PRs requires 3 +1s from committers OR
               1 +1 and 7 day wait to merge.
+ MORE details: https://s.apache.org/rtnal
-->

## Description

When running the test, `PythonTranslatorTest#shouldTranslateStrategies`, there is the potential for nondeterministic behavior due to the unspecified order of the values returned from `getConfiguration`.

Running the test:

```
mvn install -pl gremlin-core test -Dtest='org.apache.tinkerpop.gremlin.process.traversal.translator.PythonTranslatorTest#shouldTranslateStrategies'
```

The potential errors (with differences denoted between square brackets):

```
PythonTranslatorTest.shouldTranslateStrategies:112 
expected:
<...y('SeedStrategy',{'s[eed':999999,'strategy':'org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SeedStrategy']}, 'org.apache.tinke...> 
but was:
<...y('SeedStrategy',{'s[trategy':'org.apache.tinkerpop.gremlin.process.traversal.strategy.decoration.SeedStrategy','seed':999999]}, 'org.apache.tinke...>

PythonTranslatorTest.shouldTranslateStrategies:112 
expected:
<...SubgraphStrategy',{'[checkAdjacentVertices':False,'vertices':__.hasLabel('person')]}, 'org.apache.tinke...>
but was:
<...SubgraphStrategy',{'[vertices':__.hasLabel('person'),'checkAdjacentVertices':False]}, 'org.apache.tinke...>
```

## Proposed changes

Currently, the values returned from `getConfiguration` are placed in a `HashSet`, which does not retain the order of the inserted items. The `HashSet` is replaced with a `LinkedHashSet`, which will ensure the order of the keys is consistent with when each was inserted, and the inserting of items rearranged to be consistent with the test.

Ideally, the solution would be applied directly (and only) to the test code, but in this situation, it seems the best approach is to apply this change to the `getConfiguration` methods and increase the consistency of the generated code. Even though the order of these items doesn't effect the validity of the generated code, the consistency in the generated code provides a better experience by reducing volatility for code that is semantically equivalent. 